### PR TITLE
[Refatoração] - Função getData

### DIFF
--- a/script.js
+++ b/script.js
@@ -20,8 +20,8 @@ function getPessoas(){
 }
 
 function getData(value){
-  const [year, month, day] = value.split('-').map((item) => +item)
-  data = new Date(year, month - 1, day)
+  const valueDate = value + 'T03:00:00.000Z'
+  data = new Date(valueDate)
   dataFormatada = data.toLocaleDateString('pt-BR') ; 
   return dataFormatada;
 }

--- a/script.js
+++ b/script.js
@@ -20,10 +20,12 @@ function getPessoas(){
 }
 
 function getData(value){
-  data = new Date(value)
-  dataFormatada = ((data.getDate() )) + "/" + ((data.getMonth() + 1)) + "/" + data.getFullYear(); 
+  const [year, month, day] = value.split('-').map((item) => +item)
+  data = new Date(year, month - 1, day)
+  dataFormatada = data.toLocaleDateString('pt-BR') ; 
   return dataFormatada;
 }
+
 
 function addItemList(e){
   e.preventDefault()


### PR DESCRIPTION
Fala Matheus!!
Atuo como Summer da turma 19 tribo c, e em uma monitoria individual, uma pessoa estudante que havia participado da atividade, trouxe uma falha de que quando selecionava uma data tanto para checkin quanto para checkout a data era apresentada com o dia anterior ao marcado. Isso ocorria porque ao passar uma string no formato 'yyyy-mm-dd' para o new Date é descontado 3 horas da hora zero, sendo assim, foi encontrado duas soluções, a primeira ,foi a que implementei, passando como parâmetros separados do tipo number e descontado 1 no mês(pois janeiro é zero), e a segunda é adicionar um horário de 3 horas na string antes ser passada para o new Date, da seguinte forma: 'yyyy-mm-ddT03:00:00.000Z' .
Também tomei a liberdade de utilizar o toLocaleDateString('pt-BR'), para trazer a data para o formato brasileiro, assim mantém o zero em situações que o dia e o mês são de um digito.